### PR TITLE
Dissociates python-qwt version numbering from Qwt

### DIFF
--- a/qwt/__init__.py
+++ b/qwt/__init__.py
@@ -5,7 +5,8 @@
 # Copyright (c) 2015 Pierre Raybaut, for the Python translation/optimization
 # (see LICENSE file for more details)
 
-__version__ = QWT_VERSION_STR = '6.1.2a7'
+__version__ = '1.0a1'
+QWT_VERSION_STR = '6.1.2a7'
 
 import warnings
 


### PR DESCRIPTION
@picca, @stonebig: what do you think about dissociating `python-qwt` version numbering from `Qwt`?

This would allow clarifying the fact that there are limitations to the C++ to Python translation: as @uwerat judiciously pointed out, `python-qwt` is a partial port of `Qwt` and following the same version numbering as `Qwt` could lead people to think that `python-qwt` is a clone of `Qwt` (it's more a fork than a clone).

@picca: what are the consequences for the debian package?
@stonebig: is it problematic for PyPI as well? (as it could be interpreted as a downgrade)